### PR TITLE
ticker type fixup; lacks recompile

### DIFF
--- a/Defs/Things.xml
+++ b/Defs/Things.xml
@@ -24,7 +24,7 @@
     <coversFloor>true</coversFloor>
     <castEdgeShadows>true</castEdgeShadows>
     <canOverlapZones>false</canOverlapZones>
-    <tickerType>Normal</tickerType>
+    <tickerType>Rare</tickerType>
     <placeWorkers>
       <li>OpenTheWindows.PlaceWorker_Window</li>
     </placeWorkers>

--- a/Source/Building_Window.cs
+++ b/Source/Building_Window.cs
@@ -309,17 +309,7 @@ namespace OpenTheWindows
                 map.mapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
             }
         }
-        public override void Tick()
-        {
-            base.Tick();
-            if (needsUpdate)
-            {
-                if (!isFacingSet) CheckFacing();
-                CastLight();
-                Map.GetComponent<MapComp_Windows>().IncludeTileRange(illuminated);
-                needsUpdate = false;
-            }
-        }
+
         public override void TickRare()
         {
             if (Spawned)
@@ -338,6 +328,13 @@ namespace OpenTheWindows
                 {
                     AutoVentControl();
                 }
+            }
+			if (needsUpdate)
+            {
+                if (!isFacingSet) CheckFacing();
+                CastLight();
+                Map.GetComponent<MapComp_Windows>().IncludeTileRange(illuminated);
+                needsUpdate = false;
             }
             base.TickRare();
         }


### PR DESCRIPTION
Fixes #12

I tracked the issue down to the tick type being incorrect, it looks like you were using the normal tick type for lighting so that lighting would update immediately, but the temperature logic was inside TickRare() which was never being called.

This fix simply moves the lighting logic into TickRare and deletes the override for Tick(). It means the lighting updates won't happen as fast, but I'd argue that's alright. The alternative was to put the temperature logic into TIck(), which happens too often for me to believe it's performance-smart.

Apologies for not being able to include a recompile of the mod, something was wrong with my setup I think, as I was having all kinds of compile time errors that I just ended up commenting out to get it to compile while I tested.