### PR TITLE
Update MapUpdateHandler to check Spawned status

### DIFF
--- a/Source/Building_Window.cs
+++ b/Source/Building_Window.cs
@@ -634,7 +634,7 @@ namespace OpenTheWindows
 
         private void MapUpdateHandler(object sender, MapUpdateWatcher.MapUpdateInfo info)
         {
-            if (info.map != Map) return;
+            if (!Spawned || info.map != Map) return;
             var cellIdx = info.Origin;
             var cellPos = info.origin;
             bool roof = sender is RoofGrid;


### PR DESCRIPTION
Thing.Map isn't available if Thing.Spawned is false. Prevents game freeze (https://github.com/jptrrs/OpenTheWindows/issues/41).